### PR TITLE
Add devcontainer/codespace setup and docs

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,0 +1,19 @@
+FROM clojure:temurin-20-tools-deps-jammy
+# Details as of 2023-09-19:
+# Ubuntu: Ubuntu 22.04 LTS (Jammy Jellyfish)
+# JDK: eclipse-temurin 20
+# Clojure: tools-deps, 1.11.1.1347
+
+# Extra tools
+RUN apt-get update && apt-get install -y gpg curl
+
+# Install deps-new and clj-new (prefer deps-new, but clj-new is needed for some templates)
+
+RUN clojure -Ttools install io.github.seancorfield/deps-new '{:git/tag "v0.5.2"}' :as deps-new
+RUN clojure -Ttools install com.github.seancorfield/clj-new '{:git/tag "v1.2.399"}' :as clj-new
+
+# Add Babashka
+
+RUN curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install \
+  && chmod +x install \
+  && ./install --static

--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -7,10 +7,10 @@ FROM clojure:temurin-20-tools-deps-jammy
 # Extra tools
 RUN apt-get update && apt-get install -y gpg curl
 
-# Install deps-new and clj-new (prefer deps-new, but clj-new is needed for some templates)
+# Install new and clj-new (prefer new, but clj-new is needed for some templates)
 
-RUN clojure -Ttools install io.github.seancorfield/deps-new '{:git/tag "v0.5.2"}' :as deps-new
-RUN clojure -Ttools install com.github.seancorfield/clj-new '{:git/tag "v1.2.399"}' :as clj-new
+RUN clojure -Ttools install-latest :lib io.github.seancorfield/deps-new :as new
+RUN clojure -Ttools install-latest :lib com.github.seancorfield/clj-new :as clj-new
 
 # Add Babashka
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,17 +4,20 @@
     "dockerfile": "Dockerfile.dev"
   },
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  // Features to add to the dev container. More info: https://containers.dev/features.
+
+  // More info: https://containers.dev/features.
   "features": {},
+
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-  // Run commands on cluster first start.
+
+  // Run commands on cluster first start. Useful for download dependencies, etc.
   // "postCreateCommand": "",
-  // Copy host env vars into the devcontainer.  You can also refer to some_file.env files in your docker-compose setup.
+
+  // Copy host env vars into the devcontainer.  You can also refer to some_file.env files in your docker or docker-compose setup.
   "remoteEnv": {},
-  // Configure tool-specific properties.
+
   "customizations": {
-    // Editor plugins and settings
     "vscode": {
       "extensions": [
         "betterthantomorrow.calva"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "Clojure user-manager example",
+  "build": {
+    "dockerfile": "Dockerfile.dev"
+  },
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Run commands on cluster first start.
+  // "postCreateCommand": "",
+  // Copy host env vars into the devcontainer.  You can also refer to some_file.env files in your docker-compose setup.
+  "remoteEnv": {},
+  // Configure tool-specific properties.
+  "customizations": {
+    // Editor plugins and settings
+    "vscode": {
+      "extensions": [
+        "betterthantomorrow.calva"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ A variant using [Integrant](https://github.com/weavejester/integrant) and [Reiti
 
 A version of this application that uses the [Polylith architecture](https://polylith.gitbook.io/) is also available, on the [`polylith` branch](https://github.com/seancorfield/usermanager-example/tree/polylith).
 
-## Open in codespace
+## Quickstart via Devcontainers or Github Codespaces
+If you have configured your Github account, you can start the project without any other setup.  It will open a web-based vscode editor backed by a Github Codespace VM. (Codespaces is Github's hosted Devcontainer solution)
+
 [![Open in Github Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jwhitlark/usermanager-example)
+
+You can also clone this repo locally, and using vscode (with the devcontainer plugin), and Docker Desktop, run an isolated, fully setup version of this application locally. Open the repo in your editor and run the command `Dev Containers: Open Folder in Container...`.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A variant using [Integrant](https://github.com/weavejester/integrant) and [Reiti
 
 A version of this application that uses the [Polylith architecture](https://polylith.gitbook.io/) is also available, on the [`polylith` branch](https://github.com/seancorfield/usermanager-example/tree/polylith).
 
+## Open in codespace
+[![Open in Github Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jwhitlark/usermanager-example)
+
 ## Requirements
 
 This example assumes that you have a recent version of the [Clojure CLI](https://clojure.org/guides/deps_and_cli) installed (at least 1.10.3.933), and provides a `deps.edn` file, and a `build.clj` file.


### PR DESCRIPTION
Gives a `clean-room` workspace with little to no setup for experimentation.

Note that the badge Open in Codespace will need to be edited to point at the parent repository.  It can always be accessed through the `Code` button on the github site, by selecting `Codespaces` instead of `Local` on the pop-up menu.